### PR TITLE
fix(desktop): restore vendor package pruning

### DIFF
--- a/apps/desktop/scripts/prune-vendor-deps.cjs
+++ b/apps/desktop/scripts/prune-vendor-deps.cjs
@@ -14,9 +14,18 @@ const vendorDir = process.env.VENDOR_DIR_OVERRIDE
   ? path.resolve(process.env.VENDOR_DIR_OVERRIDE)
   : path.resolve(__dirname, "..", "..", "..", "vendor", "openclaw");
 const nmDir = path.join(vendorDir, "node_modules");
-const PRUNE_PROFILE_VERSION = "cross-platform-mid-blacklist-2026-08-08.1";
+const PRUNE_PROFILE_VERSION = "cross-platform-mid-blacklist-2026-08-08.2";
 const stageOfficialVendorPluginsScript = path.join(__dirname, "stage-official-vendor-plugins.cjs");
-const DISABLED_VENDOR_EXTENSIONS = ["copilot", "copilot-proxy", "github-copilot"];
+const DISABLED_VENDOR_EXTENSIONS = [
+  "copilot",
+  "copilot-proxy",
+  "github-copilot",
+  // These optional plugins are not exposed by RivonClaw Desktop. Their
+  // workspace dependencies otherwise add local inference and sandbox runtimes
+  // to every packaged app.
+  "memory-lancedb",
+  "mxc",
+];
 
 function hasCompletedProductionInstall() {
   try {
@@ -51,7 +60,22 @@ const EXTRA_REMOVE = [
   "@github/copilot",
   "@github/copilot-sdk",
 
+  // Dependencies exclusive to disabled memory-lancedb and mxc plugins.
+  "@huggingface/transformers",
+  "@lancedb",
+  "onnxruntime-common",
+  "onnxruntime-node",
+  "onnxruntime-web",
+  "@microsoft/mxc-sdk",
+  "node-pty",
+
   // Build/UI dependencies left behind by hoisted production installs.
+  "@awesome.me",
+  "@codemirror",
+  "@lezer",
+  "@openclaw/libterminal",
+  "@typescript",
+  "ghostty-web",
   "vite",
   "esbuild",
   "@esbuild",

--- a/apps/desktop/scripts/verify-vendor-runtime-contract.cjs
+++ b/apps/desktop/scripts/verify-vendor-runtime-contract.cjs
@@ -42,18 +42,41 @@ const PRUNED_FORBIDDEN_PATHS = [
   "node_modules/@openai/codex",
   "node_modules/@tloncorp/tlon-skill",
   "node_modules/@zed-industries/codex-acp",
+  "node_modules/@huggingface/transformers",
+  "node_modules/@lancedb/lancedb",
+  "node_modules/@microsoft/mxc-sdk",
+  "node_modules/@openclaw/libterminal",
+  "node_modules/ghostty-web",
+  "node_modules/node-pty",
+  "node_modules/onnxruntime-common",
+  "node_modules/onnxruntime-node",
+  "node_modules/onnxruntime-web",
   "extensions/copilot",
   "extensions/copilot-proxy",
   "extensions/github-copilot",
+  "extensions/memory-lancedb",
+  "extensions/mxc",
   "dist/extensions/copilot",
   "dist/extensions/copilot-proxy",
   "dist/extensions/github-copilot",
+  "dist/extensions/memory-lancedb",
+  "dist/extensions/mxc",
   "dist-runtime/extensions/copilot",
   "dist-runtime/extensions/copilot-proxy",
   "dist-runtime/extensions/github-copilot",
+  "dist-runtime/extensions/memory-lancedb",
+  "dist-runtime/extensions/mxc",
 ];
 
-const PRUNED_FORBIDDEN_CHILD_PREFIXES = [{ dir: "node_modules/@github", prefix: "copilot" }];
+const PRUNED_FORBIDDEN_CHILD_PREFIXES = [
+  { dir: "node_modules/@awesome.me", prefix: "webawesome" },
+  { dir: "node_modules/@codemirror", prefix: "" },
+  { dir: "node_modules/@github", prefix: "copilot" },
+  { dir: "node_modules/@lancedb", prefix: "lancedb" },
+  { dir: "node_modules/@lezer", prefix: "" },
+  { dir: "node_modules/@typescript", prefix: "typescript-" },
+];
+const TRANSIENT_TEMP_CLEANUP_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
 
 function usage() {
   console.error(
@@ -139,6 +162,22 @@ function extractArchive(archivePath) {
   return tempDir;
 }
 
+function removeTempDirBestEffort(tempDir, remove = fs.rmSync) {
+  try {
+    remove(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    return true;
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    if (!TRANSIENT_TEMP_CLEANUP_CODES.has(code)) {
+      throw error;
+    }
+    console.warn(
+      `[verify-vendor-runtime] WARN: could not remove temporary directory ${tempDir}: ${code}`,
+    );
+    return false;
+  }
+}
+
 function findWorkspaceBundles(vendorDir) {
   const distDir = path.join(vendorDir, "dist");
   const entries = fs.readdirSync(distDir, { withFileTypes: true });
@@ -222,9 +261,13 @@ async function main() {
 
     console.log(`[verify-vendor-runtime] PASS ${vendorDir}`);
   } finally {
-    fs.rmSync(stateDir, { recursive: true, force: true });
+    // Imported runtime modules can briefly retain SQLite/file handles on
+    // Windows. Cleanup must not reverse an otherwise successful contract
+    // check; the process exits immediately and the OS temp directory remains
+    // eligible for later cleanup.
+    removeTempDirBestEffort(stateDir);
     if (extractedDir) {
-      fs.rmSync(extractedDir, { recursive: true, force: true });
+      removeTempDirBestEffort(extractedDir);
     }
     if (previousStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
@@ -239,9 +282,13 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(
-    `[verify-vendor-runtime] FAIL: ${error instanceof Error ? error.message : String(error)}`,
-  );
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(
+      `[verify-vendor-runtime] FAIL: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}
+
+module.exports = { removeTempDirBestEffort };

--- a/apps/desktop/test/verify-vendor-runtime-contract.test.ts
+++ b/apps/desktop/test/verify-vendor-runtime-contract.test.ts
@@ -1,0 +1,46 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { removeTempDirBestEffort } = require("../scripts/verify-vendor-runtime-contract.cjs") as {
+  removeTempDirBestEffort: (
+    tempDir: string,
+    remove?: (path: string, options: Record<string, unknown>) => void,
+  ) => boolean;
+};
+
+describe("removeTempDirBestEffort", () => {
+  it.each(["EBUSY", "ENOTEMPTY", "EPERM"])(
+    "does not fail a successful runtime check on transient %s cleanup errors",
+    (code) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const remove = vi.fn(() => {
+        throw Object.assign(new Error("locked"), { code });
+      });
+
+      expect(removeTempDirBestEffort("temporary-state", remove)).toBe(false);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(code));
+      warn.mockRestore();
+    },
+  );
+
+  it("still surfaces non-transient cleanup errors", () => {
+    const remove = () => {
+      throw Object.assign(new Error("invalid path"), { code: "EINVAL" });
+    };
+
+    expect(() => removeTempDirBestEffort("temporary-state", remove)).toThrow("invalid path");
+  });
+
+  it("removes temporary directories with bounded retries", () => {
+    const remove = vi.fn();
+
+    expect(removeTempDirBestEffort("temporary-state", remove)).toBe(true);
+    expect(remove).toHaveBeenCalledWith("temporary-state", {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- prune optional memory-lancedb and MXC plugin runtimes that are not exposed by RivonClaw Desktop
- remove hoisted Control UI-only dependencies after the Control UI bundle is pruned
- enforce the reduced payload in the packaged runtime contract
- tolerate transient Windows temp cleanup locks after a successful runtime check

## Root cause
The upgraded OpenClaw workspace installs production dependencies for every workspace package. Optional memory-lancedb and MXC plugins pulled roughly 344 MB of unused inference and sandbox runtimes into the desktop bundle. macOS installer artifacts grew from roughly 471-486 MB to 763-765 MB.

## Verification
- isolated prune: 692 MB -> 303 MB
- archived runtime: 957 MB -> 565 MB
- runtime contract passes for both directory and tar archive on Node 24.15.0
- formatting and oxlint pass
- targeted Vitest: 5/5 pass
- commit and push hooks pass

A full four-platform Build & Release run will be triggered after merge to validate installers and artifact sizes.