### PR TITLE
fix(ci): cache complete vendor workspace builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,10 @@ jobs:
         id: cache-vendor-dist
         uses: actions/cache@v4
         with:
-          path: vendor/openclaw/dist
-          key: vendor-dist-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
+          path: |
+            vendor/openclaw/dist
+            vendor/openclaw/packages/ai/dist
+          key: vendor-dist-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
 
       # Post-prune cache: contains the production-ready dist/, pruned
       # node_modules, modified .gitignore, and stripped dist-runtime/ after
@@ -66,7 +68,7 @@ jobs:
             vendor/openclaw/node_modules
             vendor/openclaw/.gitignore
             vendor/openclaw/dist-runtime
-          key: vendor-prod-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
+          key: vendor-prod-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('scripts/setup-vendor.sh', 'apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
 
       - name: Setup OpenClaw vendor
         if: steps.cache-vendor-prod.outputs.cache-hit != 'true'
@@ -227,8 +229,10 @@ jobs:
         id: cache-vendor-dist
         uses: actions/cache@v4
         with:
-          path: vendor/openclaw/dist
-          key: vendor-dist-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
+          path: |
+            vendor/openclaw/dist
+            vendor/openclaw/packages/ai/dist
+          key: vendor-dist-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
 
       - name: Cache vendor prod
         id: cache-vendor-prod
@@ -239,7 +243,7 @@ jobs:
             vendor/openclaw/node_modules
             vendor/openclaw/.gitignore
             vendor/openclaw/dist-runtime
-          key: vendor-prod-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
+          key: vendor-prod-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('scripts/setup-vendor.sh', 'apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
 
       - name: Setup OpenClaw vendor
         if: steps.cache-vendor-prod.outputs.cache-hit != 'true'
@@ -397,8 +401,10 @@ jobs:
         id: cache-vendor-dist
         uses: actions/cache@v4
         with:
-          path: vendor/openclaw/dist
-          key: vendor-dist-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
+          path: |
+            vendor/openclaw/dist
+            vendor/openclaw/packages/ai/dist
+          key: vendor-dist-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
 
       - name: Cache vendor prod
         id: cache-vendor-prod
@@ -409,7 +415,7 @@ jobs:
             vendor/openclaw/node_modules
             vendor/openclaw/.gitignore
             vendor/openclaw/dist-runtime
-          key: vendor-prod-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
+          key: vendor-prod-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('scripts/setup-vendor.sh', 'apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
 
       - name: Setup OpenClaw vendor
         if: steps.cache-vendor-prod.outputs.cache-hit != 'true'
@@ -567,8 +573,10 @@ jobs:
         id: cache-vendor-dist
         uses: actions/cache@v4
         with:
-          path: vendor/openclaw/dist
-          key: vendor-dist-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
+          path: |
+            vendor/openclaw/dist
+            vendor/openclaw/packages/ai/dist
+          key: vendor-dist-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}
 
       # Post-prune cache: contains the production-ready dist/, pruned
       # node_modules, modified .gitignore, and stripped dist-runtime/ after
@@ -583,7 +591,7 @@ jobs:
             vendor/openclaw/node_modules
             vendor/openclaw/.gitignore
             vendor/openclaw/dist-runtime
-          key: vendor-prod-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
+          key: vendor-prod-v2-${{ runner.os }}-${{ hashFiles('.openclaw-version') }}-${{ hashFiles('vendor-patches/openclaw/*.patch') }}-${{ hashFiles('scripts/setup-vendor.sh', 'apps/desktop/scripts/prune-vendor-deps.cjs', 'apps/desktop/scripts/copy-vendor-deps.cjs', 'apps/desktop/scripts/archive-vendor-runtime.cjs', 'apps/desktop/scripts/stage-official-vendor-plugins.cjs') }}
 
       - name: Setup OpenClaw vendor
         if: steps.cache-vendor-prod.outputs.cache-hit != 'true'

--- a/apps/desktop/scripts/verify-vendor-runtime-contract.cjs
+++ b/apps/desktop/scripts/verify-vendor-runtime-contract.cjs
@@ -33,6 +33,7 @@ const REQUIRED_PATHS = [
   "node_modules/highlight.js/package.json",
   "node_modules/@larksuiteoapi/node-sdk/package.json",
   "node_modules/@openclaw/ai/package.json",
+  "node_modules/@openclaw/ai/dist/internal/runtime.mjs",
   "node_modules/openclaw/package.json",
 ];
 

--- a/scripts/setup-vendor.sh
+++ b/scripts/setup-vendor.sh
@@ -47,11 +47,25 @@ fi
 # When dist is cached, the cached output already includes patched builds
 # (the cache key incorporates patch file hashes). We still apply patches
 # to source so git state matches the built artifacts.
-# If dist cache claims to be valid but .dist-complete marker is missing,
-# the cache is incomplete (e.g. stale from a prior vendor version).
+# If dist cache claims to be valid but any required build output is missing,
+# the cache is incomplete (e.g. stale from a prior vendor version). OpenClaw
+# workspace packages are linked from node_modules, so their dist directories
+# are part of the runtime contract even though they live outside root dist/.
 # Force a full rebuild by unsetting SKIP_VENDOR_BUILD.
-if [ "${SKIP_VENDOR_BUILD:-}" = "true" ] && [ ! -f dist/.dist-complete ]; then
-  echo "WARNING: dist cache hit but .dist-complete marker missing — forcing rebuild"
+VENDOR_BUILD_OUTPUTS=(
+  "dist/.dist-complete"
+  "packages/ai/dist/internal/runtime.mjs"
+)
+MISSING_VENDOR_BUILD_OUTPUT=""
+for output in "${VENDOR_BUILD_OUTPUTS[@]}"; do
+  if [ ! -f "$output" ]; then
+    MISSING_VENDOR_BUILD_OUTPUT="$output"
+    break
+  fi
+done
+
+if [ "${SKIP_VENDOR_BUILD:-}" = "true" ] && [ -n "$MISSING_VENDOR_BUILD_OUTPUT" ]; then
+  echo "WARNING: dist cache hit but $MISSING_VENDOR_BUILD_OUTPUT is missing — forcing rebuild"
   SKIP_VENDOR_BUILD=false
   # Dev dependencies are needed for build but cached node_modules may be
   # prod-only. pnpm won't re-install dev deps if it thinks the lockfile is


### PR DESCRIPTION
## Summary
- cache the `@openclaw/ai` workspace build output alongside the root OpenClaw `dist`
- reject incomplete vendor build caches and rebuild automatically
- invalidate the malformed dist/prod caches created by the previous workflow
- assert the packaged AI runtime entrypoint explicitly

## Root cause
The macOS jobs restored root `vendor/openclaw/dist` and `node_modules`, but the latter only contained a workspace symlink to `packages/ai`. Because `packages/ai/dist` was not cached, `setup-vendor.sh` incorrectly skipped the build and the packaged runtime missed `@openclaw/ai/dist/internal/runtime.mjs`.

## Validation
- clean OpenClaw clone/install/build with all vendor patches
- production prune: 2.3 GB -> 307 MB
- packaged vendor archive runtime contract passed
- `pnpm lint`
- targeted runtime-contract tests: 5/5
- commit and pre-push hooks passed